### PR TITLE
Support for Django-Allauth

### DIFF
--- a/turbodrf/views.py
+++ b/turbodrf/views.py
@@ -8,6 +8,10 @@ from rest_framework.response import Response
 from .permissions import DefaultDjangoPermission, TurboDRFPermission
 from .serializers import TurboDRFSerializer
 
+from allauth.headless.contrib.rest_framework.authentication import (
+    XSessionTokenAuthentication,
+)
+from rest_framework import permissions
 
 class TurboDRFPagination(PageNumberPagination):
     """
@@ -133,6 +137,12 @@ class TurboDRFViewSet(viewsets.ModelViewSet):
         if not getattr(settings, "TURBODRF_DISABLE_PERMISSIONS", False)
         else []
     )
+    
+    if getattr(settings, "TURBODRF_ENABLE_ALLAUTH", False) and config.get('auth', False):
+        self.permission_classes = [permissions.IsAuthenticated]
+        self.authentication_classes = [
+            XSessionTokenAuthentication,
+        ]
     pagination_class = TurboDRFPagination
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
 


### PR DESCRIPTION
I am trying to integrate it based on https://docs.allauth.org/en/latest/headless/integrations.html#django-rest-framework

My proposal is:

```
    @classmethod
    def turbodrf(cls):
        return {
            'fields': ['first_name', 'email'],
            'auth': True
        }
```

In this way the model require the authentication, in this case as example for the User model.

In this tiny patch is incomplete as doesn't work, as if I try to set that variables in that section works but getting the `auth` value from the model is not available in that area and I don't understand how to proceed.