### PR TITLE
Get the full list of fields on the other methods

### DIFF
--- a/turbodrf/views.py
+++ b/turbodrf/views.py
@@ -194,7 +194,6 @@ class TurboDRFViewSet(viewsets.ModelViewSet):
 
         if self.action not in ["list", "detail", "retrieve"]:
             fields_to_use = "__all__"
-            
         # Store original fields before processing
         original_fields = (
             fields_to_use if isinstance(fields_to_use, list) else fields_to_use


### PR DESCRIPTION
Right now if I set on detail some fields the other are not available in swagger on the put endpoint as example.

 This fix the issue showing all the fields.