### PR TITLE
fix swagger reading TURBODRF_ROLES from package settings instead of d…

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@
 project = "TurboDRF"
 copyright = "2025, TurboDRF Team"
 author = "TurboDRF Team"
-release = "0.4.0"
+release = "0.4.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/tenancy.md
+++ b/docs/tenancy.md
@@ -125,17 +125,21 @@ return {
 Power form (when you need `Either` or `Custom`):
 
 ```python
-from turbodrf.predicates import Tenant, Owner, Either, Custom
+from turbodrf.predicates import Owner, Either, Custom
 
 return {
-    'visibility': [
-        Tenant('workspace'),
+    'tenant_field': 'workspace',          # mandatory boundary (setting)
+    'visibility': [                       # within-tenant predicates
         Either(Owner('author'), Owner('reviewer')),
     ],
 }
 ```
 
-You can't mix sugar + `visibility` on the same model.
+`tenant_field` is a setting, not a predicate, and is allowed alongside
+`visibility`. `owner_field` / `bypass_owner_roles` are sugar that compiles
+to predicates — those *do* conflict with `visibility` (pick one or the
+other). Tenant inside `visibility` is supported but deprecated; use the
+`tenant_field` setting instead.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turbodrf"
-version = "0.4.0"
+version = "0.4.1"
 description = "Dead simple Django REST API generator with role-based permissions"
 readme = "README.md"
 authors = [

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="turbodrf",
-    version="0.4.0",
+    version="0.4.1",
     author="Alexander Collins",
     author_email="",
     description="Dead simple Django REST API generator with role-based permissions",

--- a/tests/integration/test_security_authz.py
+++ b/tests/integration/test_security_authz.py
@@ -623,14 +623,16 @@ class TestPredicates(AuthzSecurityBase):
             register_predicates(Deal, orig)
 
     def test_parse_config_validation(self):
-        """parse_config rejects: non-dict, mixing visibility+sugar, non-list
-        visibility, non-Predicate visibility item, non-string tenant_field,
-        invalid owner_field type, owner_field dict."""
+        """parse_config rejects: non-dict, mixing visibility+owner-sugar,
+        non-list visibility, non-Predicate visibility item, non-string
+        tenant_field, invalid owner_field type, owner_field dict.
+        (tenant_field + visibility is now allowed — tenant is a setting,
+        not a predicate.)"""
         from turbodrf.predicates import parse_config
 
         bad_inputs = [
             [],
-            {"visibility": [], "tenant_field": "brokerage"},
+            {"visibility": [], "owner_field": "assigned_broker"},
             {"visibility": "not a list"},
             {"visibility": ["string not a predicate"]},
             {"tenant_field": 123},
@@ -1194,13 +1196,26 @@ class TestTenancyResolution(AuthzSecurityBase):
                 tenant_model_setting="test_app.Brokerage",
                 autodetect=False,
             )
-        # Mixing visibility + sugar → reject
+        # tenant_field + visibility — allowed (canonical power form)
+        tf, preds, _ = resolve_tenancy_for_model(
+            Deal,
+            {
+                "visibility": [Owner("assigned_broker")],
+                "tenant_field": "brokerage",
+            },
+            tenant_model_setting="test_app.Brokerage",
+            autodetect=False,
+        )
+        self.assertEqual(tf, "brokerage")
+        self.assertEqual(len(preds), 1)
+
+        # owner_field + visibility — reject (both compile to predicates)
         with self.assertRaises(ImproperlyConfigured):
             resolve_tenancy_for_model(
                 Deal,
                 {
                     "visibility": [Owner("assigned_broker")],
-                    "tenant_field": "brokerage",
+                    "owner_field": "assigned_broker",
                 },
                 tenant_model_setting="test_app.Brokerage",
                 autodetect=False,

--- a/tests/integration/test_security_baseline.py
+++ b/tests/integration/test_security_baseline.py
@@ -911,9 +911,11 @@ class TestParseConfigInvariants(TestCase):
             parse_config(bad_config)
         self.assertIn("Either", str(ctx.exception))
 
-    def test_mixing_sugar_and_visibility_raises(self):
-        """Mixing tenant_field= with visibility= silently dropped tenant_field
-        before; must raise instead."""
+    def test_mixing_owner_sugar_and_visibility_raises(self):
+        """`owner_field` / `bypass_owner_roles` sugar conflicts with
+        `visibility` (both compile to predicates) — must raise. But
+        `tenant_field` is a setting, not a predicate, and is allowed
+        alongside `visibility`."""
         from django.core.exceptions import ImproperlyConfigured
 
         from turbodrf.predicates import Owner, parse_config
@@ -921,11 +923,23 @@ class TestParseConfigInvariants(TestCase):
         with self.assertRaises(ImproperlyConfigured) as cm:
             parse_config(
                 {
-                    "tenant_field": "brokerage",
+                    "owner_field": "assigned_broker",
                     "visibility": [Owner("assigned_broker")],
                 }
             )
         self.assertIn("Cannot mix", str(cm.exception))
+
+        # tenant_field + visibility is the canonical power-form pairing —
+        # the deprecated `Tenant() inside visibility` form told users to
+        # use this combination. Should NOT raise.
+        tf, preds = parse_config(
+            {
+                "tenant_field": "brokerage",
+                "visibility": [Owner("assigned_broker")],
+            }
+        )
+        self.assertEqual(tf, "brokerage")
+        self.assertEqual(len(preds), 1)
 
     def test_tenant_layer_applied_separately_from_predicate_q(self):
         """Even if every predicate's Q resolves to Q() (unrestricted), the

--- a/tests/integration/test_security_predicates.py
+++ b/tests/integration/test_security_predicates.py
@@ -547,21 +547,27 @@ class TestParseConfigAndRegistration(SecurityBase):
 
     def test_unregistered_model_returns_defaults_and_clear_predicates(self):
         """Unregistered model → ([], None). clear_predicates() wipes the
-        registry; restore via register + router rehydrate."""
+        registry; restore via full snapshot."""
+        from turbodrf.predicates import _model_predicates, _model_tenant_fields
         from turbodrf.router import TurboDRFRouter
 
         self.assertEqual(get_predicates(SampleModel), [])
         self.assertIsNone(get_tenant_field(SampleModel))
 
-        orig_preds = list(get_predicates(Deal))
-        orig_tf = get_tenant_field(Deal)
+        # Snapshot the FULL registry — restoring only Deal would leave
+        # every other model unregistered for subsequent tests on this
+        # xdist worker (FK injection guards stop firing).
+        saved_p = dict(_model_predicates)
+        saved_t = dict(_model_tenant_fields)
         try:
             clear_predicates()
             self.assertEqual(get_predicates(Deal), [])
             self.assertIsNone(get_tenant_field(Deal))
         finally:
-            register_predicates(Deal, orig_preds)
-            register_tenant_field(Deal, orig_tf)
+            _model_predicates.clear()
+            _model_predicates.update(saved_p)
+            _model_tenant_fields.clear()
+            _model_tenant_fields.update(saved_t)
             TurboDRFRouter()
 
 

--- a/tests/integration/test_security_predicates.py
+++ b/tests/integration/test_security_predicates.py
@@ -484,13 +484,29 @@ class TestParseConfigAndRegistration(SecurityBase):
         """Various malformed configs must all raise ImproperlyConfigured."""
         bad_configs = [
             "string",  # not a dict
-            {"visibility": [Owner("a")], "tenant_field": "x"},  # mixed forms
+            {
+                "visibility": [Owner("a")],
+                "owner_field": "assigned_broker",
+            },  # owner sugar conflicts with visibility
             {"visibility": ["not a predicate"]},
             {"tenant_field": ["a", "b"]},  # tenant_field as list
         ]
         for cfg in bad_configs:
             with self.assertRaises(ImproperlyConfigured):
                 parse_config(cfg)
+
+    def test_tenant_field_alongside_visibility_is_allowed(self):
+        """tenant_field is a setting (not a predicate) and composes
+        cleanly with visibility=[...] — this is the canonical power-form
+        pairing now that Tenant() inside visibility is deprecated."""
+        tf, preds = parse_config(
+            {
+                "tenant_field": "brokerage",
+                "visibility": [Owner("assigned_broker")],
+            }
+        )
+        self.assertEqual(tf, "brokerage")
+        self.assertEqual(len(preds), 1)
 
     def test_valid_inputs_yield_no_predicates(self):
         """tenancy='shared' and visibility=[] both yield (None, [])."""

--- a/tests/integration/test_security_predicates.py
+++ b/tests/integration/test_security_predicates.py
@@ -41,7 +41,6 @@ from turbodrf.predicates import (
     has_tenancy_declaration,
     parse_config,
     register_predicates,
-    register_tenant_field,
 )
 
 User = get_user_model()

--- a/tests/unit/test_predicates.py
+++ b/tests/unit/test_predicates.py
@@ -518,6 +518,8 @@ class TestPredicateDefensiveBranches(TestCase):
 
     def test_clear_predicates_resets_registries(self):
         from turbodrf.predicates import (
+            _model_predicates,
+            _model_tenant_fields,
             clear_predicates,
             get_predicates,
             get_tenant_field,
@@ -528,11 +530,23 @@ class TestPredicateDefensiveBranches(TestCase):
         class Fake:
             pass
 
-        register_predicates(Fake, [Owner("x")])
-        register_tenant_field(Fake, "brokerage")
-        self.assertTrue(get_predicates(Fake))
-        self.assertEqual(get_tenant_field(Fake), "brokerage")
+        # Snapshot registry so we can restore — clear_predicates() wipes
+        # the global module state, which would break every subsequent
+        # test on this xdist worker (FK injection guards stop firing,
+        # tenant filters stop applying).
+        saved_p = dict(_model_predicates)
+        saved_t = dict(_model_tenant_fields)
+        try:
+            register_predicates(Fake, [Owner("x")])
+            register_tenant_field(Fake, "brokerage")
+            self.assertTrue(get_predicates(Fake))
+            self.assertEqual(get_tenant_field(Fake), "brokerage")
 
-        clear_predicates()
-        self.assertEqual(get_predicates(Fake), [])
-        self.assertIsNone(get_tenant_field(Fake))
+            clear_predicates()
+            self.assertEqual(get_predicates(Fake), [])
+            self.assertIsNone(get_tenant_field(Fake))
+        finally:
+            _model_predicates.clear()
+            _model_predicates.update(saved_p)
+            _model_tenant_fields.clear()
+            _model_tenant_fields.update(saved_t)

--- a/turbodrf/__init__.py
+++ b/turbodrf/__init__.py
@@ -34,7 +34,7 @@ This automatically creates:
 For more information, see: https://github.com/alexandercollins/turbodrf
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __author__ = "Alexander Collins"
 __email__ = ""
 __license__ = "MIT"

--- a/turbodrf/predicates.py
+++ b/turbodrf/predicates.py
@@ -412,20 +412,25 @@ def parse_config(config):
 
     visibility = config.get("visibility")
     if visibility is not None:
-        # Mixing sugar form with power form is ambiguous — refuse to guess
-        # which one wins. Silently dropping either side is how cross-tenant
-        # leaks happen.
+        # `tenant_field` is conceptually orthogonal to `visibility` — the
+        # tenant boundary is a setting outside the predicate algebra, while
+        # `visibility` is the within-tenant algebra. They compose cleanly
+        # and are the recommended pairing whenever you need
+        # Either/Custom alongside tenancy. `owner_field` and
+        # `bypass_owner_roles` are sugar that produces predicates which
+        # would also appear in `visibility`, so those genuinely conflict.
         conflicting = [
             k
-            for k in ("tenant_field", "owner_field", "bypass_owner_roles")
+            for k in ("owner_field", "bypass_owner_roles")
             if config.get(k) is not None
         ]
         if conflicting:
             raise ImproperlyConfigured(
                 f"Cannot mix 'visibility' with sugar keys {conflicting}. "
-                f"Pick one form: either 'visibility=[...]' (power form) OR "
-                f"'tenant_field' / 'owner_field' / 'bypass_owner_roles' "
-                f"(sugar form)."
+                f"Either use 'visibility=[...]' (and put Owner(...) inside "
+                f"it) or use 'owner_field' / 'bypass_owner_roles' sugar — "
+                f"not both. 'tenant_field' is allowed alongside "
+                f"'visibility' since it's a setting, not a predicate."
             )
         if not isinstance(visibility, (list, tuple)):
             raise ImproperlyConfigured(
@@ -439,21 +444,33 @@ def parse_config(config):
                 )
             _reject_tenant_inside_either(p)
 
-        # Extract any top-level Tenant predicates into tenant_field setting
+        # Honor an explicit tenant_field setting when present.
+        tf = config.get("tenant_field")
+        if tf is not None:
+            if not isinstance(tf, str):
+                raise ImproperlyConfigured("'tenant_field' must be a string.")
+            tenant_field = tf
+
+        # Extract any top-level Tenant predicates into tenant_field setting.
+        # Still emits a deprecation warning so the canonical form is
+        # `tenant_field=...` + within-tenant `visibility=[...]`, but no
+        # longer dead-ends users when they follow the warning's advice.
         cleaned = []
         for p in visibility:
             if isinstance(p, Tenant):
                 if tenant_field is not None and tenant_field != p.field:
                     raise ImproperlyConfigured(
-                        f"Multiple Tenant predicates in 'visibility' with "
-                        f"different fields: {tenant_field!r} and {p.field!r}. "
-                        f"Use a single 'tenant_field' setting instead."
+                        f"Multiple tenant fields declared: 'tenant_field' "
+                        f"setting is {tenant_field!r} but Tenant() inside "
+                        f"'visibility' uses {p.field!r}. Use a single "
+                        f"'tenant_field' setting."
                     )
                 tenant_field = p.field
                 warnings.warn(
                     "Tenant() inside 'visibility' is deprecated. Use the "
                     "'tenant_field' setting instead — Tenant is a mandatory "
-                    "boundary, not a composable predicate.",
+                    "boundary, not a composable predicate. The "
+                    "'tenant_field' setting can sit alongside 'visibility'.",
                     DeprecationWarning,
                     stacklevel=3,
                 )


### PR DESCRIPTION
This pull request updates TurboDRF to version 0.4.1 and introduces important changes to tenancy and visibility configuration, clarifying how `tenant_field` and `visibility` should be used together. The main improvement is that `tenant_field` is now explicitly allowed alongside `visibility`, while mixing `owner_field` or `bypass_owner_roles` with `visibility` is still disallowed. The documentation and tests have been updated to reflect this canonical "power form" configuration.

**Tenancy and visibility configuration improvements:**

* [`turbodrf/predicates.py`](diffhunk://#diff-da6927098320929577f6021da2fa1fb79e454ec5f9fb63ddb5c8446b88c700afL415-R433): `tenant_field` is now allowed alongside `visibility`, as `tenant_field` is a setting and not a predicate. Only `owner_field` and `bypass_owner_roles` are considered conflicting with `visibility`. The logic for extracting tenant boundaries has been clarified, and deprecation warnings for `Tenant()` inside `visibility` now recommend using `tenant_field` alongside `visibility`. [[1]](diffhunk://#diff-da6927098320929577f6021da2fa1fb79e454ec5f9fb63ddb5c8446b88c700afL415-R433) [[2]](diffhunk://#diff-da6927098320929577f6021da2fa1fb79e454ec5f9fb63ddb5c8446b88c700afL442-R473)

* [`docs/tenancy.md`](diffhunk://#diff-9995e38771e6ab2aac7586cc647c7a38aade3e02df0efbfc2c1659d435b35d13L128-R142): Updated documentation to clarify that `tenant_field` can be used with `visibility`, and that `owner_field`/`bypass_owner_roles` sugar conflicts with `visibility`. The use of `Tenant()` inside `visibility` is now deprecated in favor of the new canonical form.

**Testing and validation updates:**

* `tests/integration/test_security_authz.py`, `tests/integration/test_security_baseline.py`, `tests/integration/test_security_predicates.py`: Added and updated tests to ensure that using `tenant_field` with `visibility` is allowed, while mixing `owner_field` with `visibility` raises an error. Test docstrings and logic have been updated to reflect the new configuration rules. [[1]](diffhunk://#diff-74b71d068ba835a0b67e9b38611ccb7be1fa385204b1e0cda2087fdb6917938dL626-R635) [[2]](diffhunk://#diff-74b71d068ba835a0b67e9b38611ccb7be1fa385204b1e0cda2087fdb6917938dL1197-R1218) [[3]](diffhunk://#diff-949dba959488280c3e4c155d509388d4324dceebeb3061af2e9c3848692ffe2cL914-R943) [[4]](diffhunk://#diff-bb03b4a1ec0e3575adb2e9961baed44a8865c500ffad1b436d14731fa6992b9aL487-R510)

**Version bump and metadata:**

* `pyproject.toml`, `setup.py`, `turbodrf/__init__.py`, `docs/conf.py`: Bumped the version from 0.4.0 to 0.4.1 to reflect these changes. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7) [[2]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L8-R8) [[3]](diffhunk://#diff-d2f73a5555264e4f2f5b10b45cb0b48f129627a1d2191f062eb2d7e372bedd1bL37-R37) [[4]](diffhunk://#diff-85933aa74a2d66c3e4dcdf7a9ad8397f5a7971080d34ef1108296a7c6b69e7e3L12-R12)