### PR TITLE
perf(rls): wrap current_setting() in the generated tenant policy for per-statement evaluation

### DIFF
--- a/tests/unit/test_rls_generation.py
+++ b/tests/unit/test_rls_generation.py
@@ -23,11 +23,11 @@ from turbodrf.predicates import (
 class TestTenantRLS(TestCase):
     def test_simple_field(self):
         clause = Tenant("brokerage").to_rls_using_clause()
-        self.assertEqual(clause, "brokerage_id = current_setting('app.tenant_id')::int")
+        self.assertEqual(clause, "brokerage_id = (select current_setting('app.tenant_id')::int)")
 
     def test_field_already_with_id_suffix(self):
         clause = Tenant("brokerage_id").to_rls_using_clause()
-        self.assertEqual(clause, "brokerage_id = current_setting('app.tenant_id')::int")
+        self.assertEqual(clause, "brokerage_id = (select current_setting('app.tenant_id')::int)")
 
     def test_chained_path_raises(self):
         with self.assertRaises(NotImplementedError):
@@ -37,24 +37,24 @@ class TestTenantRLS(TestCase):
         sql = Tenant("brokerage").to_rls_policy("deal_table")
         self.assertIn("CREATE POLICY", sql)
         self.assertIn("ON deal_table", sql)
-        self.assertIn("brokerage_id = current_setting", sql)
+        self.assertIn("brokerage_id = (select current_setting", sql)
 
 
 class TestOwnerRLS(TestCase):
     def test_simple_owner(self):
         clause = Owner("assigned_to").to_rls_using_clause()
-        self.assertEqual(clause, "assigned_to_id = current_setting('app.user_id')::int")
+        self.assertEqual(clause, "assigned_to_id = (select current_setting('app.user_id')::int)")
 
     def test_owner_with_bypass(self):
         clause = Owner("assigned_to", bypass=["admin", "manager"]).to_rls_using_clause()
-        self.assertIn("assigned_to_id = current_setting('app.user_id')::int", clause)
-        self.assertIn("current_setting('app.user_roles')", clause)
+        self.assertIn("assigned_to_id = (select current_setting('app.user_id')::int)", clause)
+        self.assertIn("(select current_setting('app.user_roles'))", clause)
         self.assertIn("admin|manager", clause)
 
     def test_multi_owner_or(self):
         clause = Owner(["author", "editor"]).to_rls_using_clause()
-        self.assertIn("author_id = current_setting('app.user_id')::int", clause)
-        self.assertIn("editor_id = current_setting('app.user_id')::int", clause)
+        self.assertIn("author_id = (select current_setting('app.user_id')::int)", clause)
+        self.assertIn("editor_id = (select current_setting('app.user_id')::int)", clause)
         self.assertIn(" OR ", clause)
 
     def test_chained_owner_raises(self):

--- a/turbodrf/predicates.py
+++ b/turbodrf/predicates.py
@@ -149,7 +149,7 @@ class Tenant(Predicate):
                 f"tenant FK column."
             )
         col = self.field if self.field.endswith("_id") else f"{self.field}_id"
-        return f"{col} = current_setting('app.tenant_id')::int"
+        return f"{col} = (select current_setting('app.tenant_id')::int)"
 
 
 class Owner(Predicate):
@@ -216,13 +216,13 @@ class Owner(Predicate):
         col_clauses = []
         for f in self.fields:
             col = f if f.endswith("_id") else f"{f}_id"
-            col_clauses.append(f"{col} = current_setting('app.user_id')::int")
+            col_clauses.append(f"{col} = (select current_setting('app.user_id')::int)")
         owner_clause = " OR ".join(col_clauses)
         if self.bypass:
             roles = "|".join(sorted(self.bypass))
             return (
                 f"({owner_clause}) OR "
-                f"current_setting('app.user_roles') ~ E'\\\\m({roles})\\\\M'"
+                f"(select current_setting('app.user_roles')) ~ E'\\\\m({roles})\\\\M'"
             )
         return owner_clause
 


### PR DESCRIPTION
`AlexanderCollins/TurboDRF`'s RLS policy generator emits `current_setting('<tenant setting>')` **unwrapped** in the policy predicate. Postgres re-evaluates a bare `current_setting(...)` **once per row** the policy scans; wrapping it in a scalar subquery — `(select current_setting(...))` — makes it a per-statement InitPlan the planner evaluates once and caches. It's predicate-equivalent (tenant isolation unchanged) and the documented Postgres RLS performance pattern; the benefit grows with table size.

This wraps the generated call and keeps the test assertions in sync (`predicates.py`, `test_rls_generation.py`). I couldn't run the Python / Django test suite locally — if CI surfaces another assertion on the generated policy SQL, point me at it and I'll update it.

Spotted with [pgrls](https://github.com/pgrls/pgrls) (an open-source Postgres RLS analyzer). Happy to adjust.